### PR TITLE
add blank block so new post can be seen

### DIFF
--- a/src/Discussion.js
+++ b/src/Discussion.js
@@ -29,6 +29,7 @@ const Discussion = ({ posts }) => {
         <div>
           <Preview posts={homePosts} allPosts={posts} />
           <Preview posts={discussionPosts} allPosts={posts} />
+          <div className="discussion-end-block"></div>
         </div>
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -299,6 +299,11 @@ h4 {
   background-color: rgb(238, 246, 254);
 }
 
+.discussion-end-block {
+  height: 100%;
+  min-height: 183px;
+}
+
 .preview.card {
   width: 346px;
   height: 100%;


### PR DESCRIPTION
I added some space so the newest post can be seen and not blocked by the add post button

<img width="376" alt="Screen Shot 2022-04-26 at 12 23 20 PM" src="https://user-images.githubusercontent.com/30136716/165347232-6d496d1c-dd83-44fb-b79b-a1f974c75f76.png">
